### PR TITLE
Fix base_url double v1 bug

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,13 @@ from langchain.prompts import ChatPromptTemplate
 from langchain_mongodb import MongoDBChatMessageHistory
 
 def main():
-    llm_url = os.environ.get('url', 'http://localhost:1234').strip().strip('/')
+    colorama.init()
+    # sanitize LLM endpoint, ensuring we don't append '/v1' twice
+    llm_url = os.environ.get('url', 'http://localhost:1234').strip().rstrip('/')
+    if llm_url.endswith('/v1'):
+        base_url = llm_url
+    else:
+        base_url = f"{llm_url}/v1"
     llm_model = os.environ.get('model', 'meta-llama-3.1-8b-instruct').strip()
     mongo_url = os.environ.get('mongo', 'mongodb://localhost:27017').strip()
     api_key = os.environ.get('OPENAI_API_KEY', 'dummy').strip()
@@ -26,7 +32,7 @@ def main():
     print()
 
     # llm
-    llm = ChatOpenAI(base_url=f"{llm_url}/v1", model=llm_model, api_key=api_key)
+    llm = ChatOpenAI(base_url=base_url, model=llm_model, api_key=api_key)
 
     # history
     history = MongoDBChatMessageHistory(


### PR DESCRIPTION
## Summary
- avoid appending `/v1` twice when `url` already ends with `/v1`
- initialize colorama for consistent terminal colors

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_683ff6f44be48321b1adf61d46c41bdd