### PR TITLE
Fix setup directory name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is a minimal Python terminal application for experimenting with local LLMs 
 ### 1. Clone and prepare
 ```bash
 git clone <this-repo-url>
-cd local-models
+cd Local-Ai-Experiments
 python3 -m venv venv
 source venv/bin/activate
 ```


### PR DESCRIPTION
## Summary
- correct the setup path in README.md

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_683ff88c651c83218dffcfa8416f7eae