### PR TITLE
Initialize colorama with autoreset

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,8 @@ from langchain.prompts import ChatPromptTemplate
 from langchain_mongodb import MongoDBChatMessageHistory
 
 def main():
-    colorama.init()
+    # initialize color support for terminal output
+    colorama.init(autoreset=True)
     # sanitize LLM endpoint, ensuring we don't append '/v1' twice
     llm_url = os.environ.get('url', 'http://localhost:1234').strip().rstrip('/')
     if llm_url.endswith('/v1'):


### PR DESCRIPTION
## Summary
- initialize colorama with `autoreset=True` to ensure colored output resets automatically

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_683ff88eb5508321bc16fcb39965bc0a