### PR TITLE
Add pytest session ID tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -64,3 +64,4 @@ urllib3==2.4.0
 xxhash==3.5.0
 yarl==1.20.0
 zstandard==0.23.0
+pytest==8.2.2

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,93 @@
+import sys
+import pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import builtins
+import uuid
+from types import SimpleNamespace
+
+class DummyMessagesPlaceholder:
+    def __init__(self, *args, **kwargs):
+        pass
+
+class DummyPromptTemplate:
+    @classmethod
+    def from_messages(cls, msgs):
+        return cls()
+
+    def __or__(self, other):
+        return other
+
+sys.modules.setdefault(
+    "langchain.prompts",
+    SimpleNamespace(MessagesPlaceholder=DummyMessagesPlaceholder, ChatPromptTemplate=DummyPromptTemplate),
+)
+sys.modules.setdefault(
+    "langchain_core.runnables.history",
+    SimpleNamespace(RunnableWithMessageHistory=object),
+)
+sys.modules.setdefault(
+    "langchain_openai",
+    SimpleNamespace(ChatOpenAI=object),
+)
+sys.modules.setdefault(
+    "langchain_mongodb",
+    SimpleNamespace(MongoDBChatMessageHistory=object),
+)
+sys.modules.setdefault(
+    "colorama",
+    SimpleNamespace(
+        init=lambda *a, **k: None,
+        Style=SimpleNamespace(BRIGHT="", RESET_ALL=""),
+        Fore=SimpleNamespace(GREEN="", BLUE="", YELLOW="", RED=""),
+    ),
+)
+
+import pytest
+
+import app
+
+
+class DummyChain:
+    def __init__(self, captured):
+        self.captured = captured
+
+    def stream(self, *args, **kwargs):
+        self.captured['session_id'] = kwargs['config']['configurable']['session_id']
+        raise KeyboardInterrupt
+
+
+@pytest.fixture(autouse=True)
+def patch_dependencies(monkeypatch):
+    monkeypatch.setattr(app, 'ChatOpenAI', lambda **kw: object())
+    monkeypatch.setattr(app, 'MongoDBChatMessageHistory', lambda **kw: object())
+
+    captured = {}
+
+    def make_dummy_chain(chain, get_session_history, input_messages_key, history_messages_key):
+        return DummyChain(captured)
+
+    monkeypatch.setattr(app, 'RunnableWithMessageHistory', make_dummy_chain)
+
+    yield captured
+
+
+def run_app_with_args(monkeypatch, args):
+    monkeypatch.setattr(sys, 'argv', ['app.py'] + args)
+    monkeypatch.setattr(builtins, 'input', lambda _: 'hi')
+    with pytest.raises(SystemExit):
+        app.main()
+
+
+def test_valid_uuid(monkeypatch, patch_dependencies):
+    valid = str(uuid.uuid4())
+    run_app_with_args(monkeypatch, [valid])
+    assert patch_dependencies['session_id'] == valid
+
+
+def test_invalid_uuid(monkeypatch, patch_dependencies):
+    invalid = 'not-a-valid-uuid'
+    run_app_with_args(monkeypatch, [invalid])
+    captured = patch_dependencies['session_id']
+    uuid_obj = uuid.UUID(captured)
+    assert str(uuid_obj) == captured
+    assert captured != invalid


### PR DESCRIPTION
## Summary
- add pytest to requirements
- create tests covering session_id logic

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff88bd37c8321b4cd9c5cdff0b5c7