### PR TITLE
Fix comment for API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pip install -r requirements.txt
 export url=http://localhost:1234              # LLM endpoint
 export model=meta-llama-3.1-8b-instruct       # LLM model name
 export mongo=mongodb://localhost:27017        # MongoDB URI
-export OPENAI_API_KEY=dummy                   # OpenAI apikey
+export OPENAI_API_KEY=dummy                   # OpenAI API key
 ```
 
 ---


### PR DESCRIPTION
## Summary
- update OpenAI API key comment in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff8919c948321879a6397214f68fa